### PR TITLE
feat: Add Group Member Count Report blocks

### DIFF
--- a/_code/Block-DynamicData/GroupMemberCountReport_Page3604/Block5683-GroupMemberTable.lava
+++ b/_code/Block-DynamicData/GroupMemberCountReport_Page3604/Block5683-GroupMemberTable.lava
@@ -37,24 +37,25 @@
 
     {% if showExtraInfo %}
     -- Show extra info
-    SELECT gm.[Id],  -- DISTINCT to avoid duplication
-        CONCAT(p0.[NickName], ' ', p0.[LastName]) AS 'Person',
-        gtr.[Name] as [CurrentRole],
-        CASE
+    SELECT
+        gm.[Id]  -- DISTINCT to avoid duplication
+      , CONCAT(p0.[NickName], ' ', p0.[LastName]) AS 'Person'
+      , gtr.[Name] as [CurrentRole]
+      , CASE
             WHEN gm.[GroupMemberStatus] = 0 THEN 'Inactive'
             WHEN gm.[GroupMemberStatus] = 1 THEN 'Active'
             WHEN gm.[GroupMemberStatus] = 2 THEN 'Pending'
             ELSE 'Unknown'
-        END AS [CurrentStatus],
-        gm.[CreatedDateTime],
-        CONCAT(p1.[NickName], ' ', p1.[LastName]) AS 'CreatedBy',
-        gm.[ModifiedDateTime],
-        CONCAT(p2.[NickName], ' ', p2.[LastName]) AS 'ModifiedBy',
-        gm.[DateTimeAdded],
-        gm.[InactiveDateTime],
-        gm.[IsArchived],
-        gm.[ArchivedDateTime],
-        CONCAT(p3.[NickName], ' ', p3.[LastName]) AS 'ArchivedBy'
+        END AS 'CurrentStatus'
+      , gm.[CreatedDateTime]
+      , CONCAT(p1.[NickName], ' ', p1.[LastName]) AS 'CreatedBy'
+      , gm.[ModifiedDateTime]
+      , CONCAT(p2.[NickName], ' ', p2.[LastName]) AS 'ModifiedBy'
+      , gm.[DateTimeAdded]
+      , gm.[InactiveDateTime]
+      , gm.[IsArchived]
+      , gm.[ArchivedDateTime]
+      , CONCAT(p3.[NickName], ' ', p3.[LastName]) AS 'ArchivedBy'
     FROM [GroupMemberHistorical] gmh
     LEFT JOIN [GroupMember] gm ON gm.[Id] = gmh.[GroupMemberId]
     LEFT JOIN [Person] p0 ON p0.[Id] = gm.[PersonId]
@@ -70,16 +71,17 @@
     LEFT JOIN [GroupTypeRole] gtr ON gtr.[Id] = gm.[GroupRoleId]
     {% else %}
     -- Show only Name, Role, and DateTimeAdded
-    SELECT gm.[Id],  -- DISTINCT to avoid duplication
-        CONCAT(p0.[NickName], ' ', p0.[LastName]) AS 'Person',
-        gtr.[Name] as [CurrentRole],
-        CASE
+    SELECT
+        gm.[Id] -- DISTINCT to avoid duplication
+      , CONCAT(p0.[NickName], ' ', p0.[LastName]) AS 'Person'
+      , gtr.[Name] AS 'CurrentRole'
+      , CASE
             WHEN gm.[GroupMemberStatus] = 0 THEN 'Inactive'
             WHEN gm.[GroupMemberStatus] = 1 THEN 'Active'
             WHEN gm.[GroupMemberStatus] = 2 THEN 'Pending'
             ELSE 'Unknown'
-        END AS [CurrentStatus],
-        gm.[DateTimeAdded]
+        END AS [CurrentStatus]
+      , gm.[DateTimeAdded]
     FROM [GroupMemberHistorical] gmh
     LEFT JOIN [GroupMember] gm ON gm.[Id] = gmh.[GroupMemberId]
     LEFT JOIN [Person] p0 ON p0.[Id] = gm.[PersonId]

--- a/_code/Block-DynamicData/GroupMemberCountReport_Page3604/Block5683-GroupMemberTable.lava
+++ b/_code/Block-DynamicData/GroupMemberCountReport_Page3604/Block5683-GroupMemberTable.lava
@@ -1,0 +1,105 @@
+/------------------------------------------------------------
+    This Lava is found in
+    PageId=3604, [Dynamic Data] > Query
+
+    This Lava is used to generate a query for a table of group members for a group at a specified month/year.
+
+    Path:
+    _code/Block-DynamicData/GroupMemberCountReport_Page3604/Block5683-GroupMemberTable.lava
+------------------------------------------------------------/
+
+{% if PageParameter.Group %}
+    {% group where:'Guid == "{{ PageParameter.Group }}"' securityenabled:'false' %}
+    {% endgroup %}
+
+    {% assign showExtraInfo = PageParameter.ShowExtraInfo | AsBoolean %}
+
+    {% assign nowDateTime = 'Now' | Date %}
+    {% assign currentMonth = nowDateTime | Date:'M' %}
+    {% assign currentYear = nowDateTime | Date:'yyyy' %}
+
+    {% if PageParameter.Month and PageParameter.Year %}
+        {% assign month = PageParameter.Month | AsInteger %}
+        {% assign year = PageParameter.Year | AsInteger %}
+        {% if year >= currentYear %}
+            {% assign year = currentYear %}
+            {% if month > currentMonth %}
+                {% assign month = currentMonth %}
+            {% endif %}
+        {% endif %}
+    {% else %}
+        {% assign month = currentMonth %}
+        {% assign year = currentYear %}
+    {% endif %}
+
+    {% capture targetMonthEndDate %}{{ year }}-{% if month < 10 %}0{% endif %}{{ month }}-01{% endcapture %}
+    {% assign targetMonthEndDate = targetMonthEndDate | DateAdd:1,'M' | DateAdd:-1,'d' | Date:'yyyy-MM-dd' %}
+
+    {% if showExtraInfo %}
+    -- Show extra info
+    SELECT gm.[Id],  -- DISTINCT to avoid duplication
+        CONCAT(p0.[NickName], ' ', p0.[LastName]) AS 'Person',
+        gtr.[Name] as [CurrentRole],
+        CASE
+            WHEN gm.[GroupMemberStatus] = 0 THEN 'Inactive'
+            WHEN gm.[GroupMemberStatus] = 1 THEN 'Active'
+            WHEN gm.[GroupMemberStatus] = 2 THEN 'Pending'
+            ELSE 'Unknown'
+        END AS [CurrentStatus],
+        gm.[CreatedDateTime],
+        CONCAT(p1.[NickName], ' ', p1.[LastName]) AS 'CreatedBy',
+        gm.[ModifiedDateTime],
+        CONCAT(p2.[NickName], ' ', p2.[LastName]) AS 'ModifiedBy',
+        gm.[DateTimeAdded],
+        gm.[InactiveDateTime],
+        gm.[IsArchived],
+        gm.[ArchivedDateTime],
+        CONCAT(p3.[NickName], ' ', p3.[LastName]) AS 'ArchivedBy'
+    FROM [GroupMemberHistorical] gmh
+    LEFT JOIN [GroupMember] gm ON gm.[Id] = gmh.[GroupMemberId]
+    LEFT JOIN [Person] p0 ON p0.[Id] = gm.[PersonId]
+    LEFT JOIN [PersonAlias] pa1 ON pa1.[Id] = gm.[CreatedByPersonAliasId]
+        AND pa1.[PersonId] = pa1.[AliasPersonId]
+    LEFT JOIN [Person] p1 ON p1.[Id] = pa1.[PersonId]
+    LEFT JOIN [PersonAlias] pa2 ON pa2.[Id] = gm.[ModifiedByPersonAliasId]
+        AND pa2.[PersonId] = pa2.[AliasPersonId]
+    LEFT JOIN [Person] p2 ON p2.[Id] = pa2.[PersonId]
+    LEFT JOIN [PersonAlias] pa3 ON pa3.[Id] = gm.[ArchivedByPersonAliasId]
+        AND pa3.[PersonId] = pa3.[AliasPersonId]
+    LEFT JOIN [Person] p3 ON p3.[Id] = pa3.[PersonId]
+    LEFT JOIN [GroupTypeRole] gtr ON gtr.[Id] = gm.[GroupRoleId]
+    {% else %}
+    -- Show only Name, Role, and DateTimeAdded
+    SELECT gm.[Id],  -- DISTINCT to avoid duplication
+        CONCAT(p0.[NickName], ' ', p0.[LastName]) AS 'Person',
+        gtr.[Name] as [CurrentRole],
+        CASE
+            WHEN gm.[GroupMemberStatus] = 0 THEN 'Inactive'
+            WHEN gm.[GroupMemberStatus] = 1 THEN 'Active'
+            WHEN gm.[GroupMemberStatus] = 2 THEN 'Pending'
+            ELSE 'Unknown'
+        END AS [CurrentStatus],
+        gm.[DateTimeAdded]
+    FROM [GroupMemberHistorical] gmh
+    LEFT JOIN [GroupMember] gm ON gm.[Id] = gmh.[GroupMemberId]
+    LEFT JOIN [Person] p0 ON p0.[Id] = gm.[PersonId]
+    LEFT JOIN [GroupTypeRole] gtr ON gtr.[Id] = gm.[GroupRoleId]
+    {% endif %}
+    WHERE gmh.[GroupId] = {{ group.Id }}
+        AND gmh.[EffectiveDateTime] <= '{{ targetMonthEndDate }}'  -- Member was active by the end of the month
+        AND (
+            gmh.[ArchivedDateTime] IS NULL  -- Ensure they are not archived
+            OR gmh.[ArchivedDateTime] > '{{ targetMonthEndDate }}'
+        )
+        AND (
+            gmh.[InactiveDateTime] IS NULL  -- Ensure they are not inactive
+            OR gmh.[InactiveDateTime] > '{{ targetMonthEndDate }}'
+        )
+        AND (
+            gmh.[ExpireDateTime] IS NULL  -- Ensure they are not expired
+            OR gmh.[ExpireDateTime] > '{{ targetMonthEndDate }}'
+        )
+    ORDER BY gmh.[Id];
+{% else %}
+    select 'Please input the required filters.' as [No Results];
+{% endif %}

--- a/_code/Block-DynamicData/GroupMemberCountReport_Page3604/README.md
+++ b/_code/Block-DynamicData/GroupMemberCountReport_Page3604/README.md
@@ -1,0 +1,5 @@
+# Report For Group Member Reporting
+Tools > Reporting > [Group Member Count Report](https://rock.vrl.church/reporting/group-member-count) [PageId=3604] is a Page created by DTS & VRL to satisfy a request to view group member counts historically.
+
+## Group Member Table [BlockId=5683]
+This Dynamic Data Block shows a list of group members at a specified time for a group using GroupMemberHistorical.

--- a/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5685-SummaryCard.lava
+++ b/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5685-SummaryCard.lava
@@ -34,13 +34,13 @@
     {% assign targetMonthEndDate = targetMonthEndDate | DateAdd:1,'M' | DateAdd:-1,'d' | Date:'yyyy-MM-dd' %}
 
     {% sql return:'GroupCountMetric' %}
-    select top(1) mv.[YValue] as [Count]
-    from [MetricValue] mv
-        join [MetricValuePartition] mvp on mvp.[MetricValueId] = mv.[Id]
-        join [MetricPartition] mp on mp.[Id] = mvp.[MetricPartitionId] and mp.[EntityTypeId] = 16
-    where mv.[MetricId] = 74
-        and mvp.[EntityId] = {{ group.Id }}
-        and mv.[MetricValueDateTime] = '{{ targetMonthEndDate }}';
+    SELECT TOP(1) mv.[YValue] AS 'Count'
+    FROM [MetricValue] mv
+        JOIN [MetricValuePartition] mvp ON mvp.[MetricValueId] = mv.[Id]
+        JOIN [MetricPartition] mp ON mp.[Id] = mvp.[MetricPartitionId] AND mp.[EntityTypeId] = 16
+    WHERE mv.[MetricId] = 74
+        AND mvp.[EntityId] = {{ group.Id }}
+        AND mv.[MetricValueDateTime] = '{{ targetMonthEndDate }}';
     {% endsql %}
     {% assign groupMemberCount = GroupCountMetric | Select:'Count' | First %}
 

--- a/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5685-SummaryCard.lava
+++ b/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5685-SummaryCard.lava
@@ -1,0 +1,54 @@
+/------------------------------------------------------------
+    This Lava is found in
+    PageId=3604, [HTML Content] > Content
+
+    This Lava is used to display a summary card of the member count for a group.
+
+    Path:
+    _code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5685-SummaryCard.lava
+------------------------------------------------------------/
+
+{% if PageParameter.Month and PageParameter.Year and PageParameter.Group %}
+    {% group where:'Guid == "{{ PageParameter.Group }}"' securityenabled:'false' %}
+    {% endgroup %}
+
+    {% assign nowDateTime = 'Now' | Date %}
+    {% assign currentMonth = nowDateTime | Date:'M' %}
+    {% assign currentYear = nowDateTime | Date:'yyyy' %}
+
+    {% if PageParameter.Month and PageParameter.Year %}
+        {% assign month = PageParameter.Month | AsInteger %}
+        {% assign year = PageParameter.Year | AsInteger %}
+        {% if year >= currentYear %}
+            {% assign year = currentYear %}
+            {% if month > currentMonth %}
+                {% assign month = currentMonth %}
+            {% endif %}
+        {% endif %}
+    {% else %}
+        {% assign month = currentMonth %}
+        {% assign year = currentYear %}
+    {% endif %}
+
+    {% capture targetMonthEndDate %}{{ year }}-{% if month < 10 %}0{% endif %}{{ month }}-01{% endcapture %}
+    {% assign targetMonthEndDate = targetMonthEndDate | DateAdd:1,'M' | DateAdd:-1,'d' | Date:'yyyy-MM-dd' %}
+
+    {% sql return:'GroupCountMetric' %}
+    select top(1) mv.[YValue] as [Count]
+    from [MetricValue] mv
+        join [MetricValuePartition] mvp on mvp.[MetricValueId] = mv.[Id]
+        join [MetricPartition] mp on mp.[Id] = mvp.[MetricPartitionId] and mp.[EntityTypeId] = 16
+    where mv.[MetricId] = 74
+        and mvp.[EntityId] = {{ group.Id }}
+        and mv.[MetricValueDateTime] = '{{ targetMonthEndDate }}';
+    {% endsql %}
+    {% assign groupMemberCount = GroupCountMetric | Select:'Count' | First %}
+
+    <div class="panel p-4">
+        On {{ targetMonthEndDate | Date:'MMMM d, yyyy' }},<br/>
+        There were <b>{{ groupMemberCount | Format:'##,#0' }}</b> members in the <b>{{ group.Name }}</b> group.
+        <br/>
+        <br/>
+        <small>If a member was deleted instead of being archived or inactivated - they will not reflect in this report.</small>
+    </div>
+{% endif %}

--- a/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5686-BarChart.lava
+++ b/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5686-BarChart.lava
@@ -40,19 +40,19 @@
     ),
     MetricValuesPerMonth AS (
         SELECT
-            ml.MonthEnd AS [Date],
-            mv.[YValue] AS MemberCount
-        FROM MonthList ml
-        LEFT JOIN [MetricValue] mv ON EOMONTH(mv.[MetricValueDateTime]) = ml.MonthEnd
+            ml.[MonthEnd] AS 'Date'
+          , mv.[YValue] AS 'MemberCount'
+        FROM [MonthList] ml
+        LEFT JOIN [MetricValue] mv ON EOMONTH(mv.[MetricValueDateTime]) = ml.[MonthEnd]
         JOIN [MetricValuePartition] mvp ON mvp.[MetricValueId] = mv.[Id]
         JOIN [MetricPartition] mp ON mp.[Id] = mvp.[MetricPartitionId]
         WHERE mv.[MetricId] = 74  -- Use the correct MetricId
         AND mvp.[EntityId] = {{ group.Id }}  -- Ensure we are matching the correct group
     )
     SELECT
-        [Date],
-        MemberCount
-    FROM MetricValuesPerMonth
+        [Date]
+      , [MemberCount]
+    FROM [MetricValuesPerMonth]
     ORDER BY [Date];
     {% endsql %}
 

--- a/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5686-BarChart.lava
+++ b/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5686-BarChart.lava
@@ -1,0 +1,131 @@
+/------------------------------------------------------------
+    This Lava is found in
+    PageId=3604, [HTML Content] > Content
+
+    This Lava is used to display a bar chart of the member count history for a group.
+
+    Path:
+    _code/Block-HTMLContent/GroupMemberCountReport_Page3604/Block5686-BarChart.lava
+------------------------------------------------------------/
+
+{% if PageParameter.Group %}
+    {% group where:'Guid == "{{ PageParameter.Group }}"' securityenabled:'false' %}
+    {% endgroup %}
+
+    {% assign nowDateTime = 'Now' | Date %}
+    {% assign currentMonth = nowDateTime | Date:'M' %}
+    {% assign currentYear = nowDateTime | Date:'yyyy' %}
+
+    {% if PageParameter.Month and PageParameter.Year %}
+        {% assign month = PageParameter.Month | AsInteger %}
+        {% assign year = PageParameter.Year | AsInteger %}
+        {% if year >= currentYear %}
+            {% assign year = currentYear %}
+            {% if month > currentMonth %}
+                {% assign month = currentMonth %}
+            {% endif %}
+        {% endif %}
+    {% else %}
+        {% assign month = currentMonth %}
+        {% assign year = currentYear %}
+    {% endif %}
+
+    {% capture targetMonthEndDate %}{{ year }}-{% if month < 10 %}0{% endif %}{{ month }}-01{% endcapture %}
+    {% assign targetMonthEndDate = targetMonthEndDate | DateAdd:1,'M' | DateAdd:-1,'d' | Date:'yyyy-MM-dd' %}
+
+    {% sql return:'ChartData' %}
+    WITH MonthList AS (
+        SELECT EOMONTH(DATEADD(MONTH, -n, {% if PageParameter.Month and PageParameter.Year %}'{{ targetMonthEndDate }}'{% else %}GETDATE(){% endif %})) AS MonthEnd
+        FROM (VALUES (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11)) AS x(n)
+    ),
+    MetricValuesPerMonth AS (
+        SELECT
+            ml.MonthEnd AS [Date],
+            mv.[YValue] AS MemberCount
+        FROM MonthList ml
+        LEFT JOIN [MetricValue] mv ON EOMONTH(mv.[MetricValueDateTime]) = ml.MonthEnd
+        JOIN [MetricValuePartition] mvp ON mvp.[MetricValueId] = mv.[Id]
+        JOIN [MetricPartition] mp ON mp.[Id] = mvp.[MetricPartitionId]
+        WHERE mv.[MetricId] = 74  -- Use the correct MetricId
+        AND mvp.[EntityId] = {{ group.Id }}  -- Ensure we are matching the correct group
+    )
+    SELECT
+        [Date],
+        MemberCount
+    FROM MetricValuesPerMonth
+    ORDER BY [Date];
+    {% endsql %}
+
+    {% if ChartData != empty %}
+        <div class="panel panel-block">
+            <div class="panel-heading">
+                <h1 class="panel-title">
+                    <i class="fa fa-people"></i>
+                    <span> Member Count History</span>
+                </h1>
+            </div>
+            <div class="panel-body">
+                <canvas id="groupCountChart" width="400" height="100"></canvas>
+            </div>
+        </div>
+
+        <script>
+            var ctx = document.getElementById('groupCountChart').getContext('2d');
+
+            var labels = [
+                {% for row in ChartData %}
+                    "{{ row.Date | Date:'MMMM yyyy' }}"{% if forloop.last == false %}, {% endif %}
+                {% endfor %}
+            ];
+
+            var data = [
+                {% for row in ChartData %}
+                    {{ row.MemberCount }}{% if forloop.last == false %}, {% endif %}
+                {% endfor %}
+            ];
+
+            var chartData = {
+                labels,
+                datasets: [{
+                    label: 'Active Members',
+                    data,
+                    backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    borderWidth: 1
+                }]
+            };
+
+            var myChart = new Chart(ctx, {
+                type: 'bar',
+                data: chartData,
+                options: {
+                    scales: {
+                        y: {
+                            beginAtZero: true
+                        }
+                    },
+                    onClick: function(evt) {
+                        var activePoints = myChart.getElementsAtEventForMode(evt, 'nearest', { intersect: true }, true);
+                        if (activePoints.length > 0) {
+                            var index = activePoints[0].index;
+                            var label = labels[index];
+                            var selectedDate = new Date(label + ' 01');
+
+                            var month = selectedDate.getMonth() + 1; // JavaScript months are 0-based
+                            var year = selectedDate.getFullYear();
+
+                            // Update URL with Month and Year parameters
+                            var newUrl = new URL(window.location.href);
+                            newUrl.searchParams.set('Month', month);
+                            newUrl.searchParams.set('Year', year);
+
+                            window.location.href = newUrl.toString();
+                        }
+                    }
+                }
+            });
+        </script>
+    {% else %}
+        <p>No data available to display the chart.</p>
+    {% endif %}
+{% endif %}

--- a/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/README.md
+++ b/_code/Block-HTMLContent/GroupMemberCountReport_Page3604/README.md
@@ -1,0 +1,8 @@
+# Report For Group Member Reporting
+Tools > Reporting > [Group Member Count Report](https://rock.vrl.church/reporting/group-member-count) [PageId=3604] is a Page created by DTS & VRL to satisfy a request to view group member counts historically.
+
+## Summary Card [BlockId=5685]
+This HTML block provides a summary based on the page parameter filters.
+
+## Bar Chart [BlockId=5686]
+This HTML block renders the counts historically in a bar chart using Chart.JS.


### PR DESCRIPTION
The code changes include adding new blocks for the Group Member Count Report page. These blocks include a Group Member Table and a Summary Card. The blocks are designed to display historical group member counts and provide a summary based on page parameter filters.