### PR TITLE
Fix typo in boilerplate

### DIFF
--- a/_code/Block-DynamicData/Report_LifeGroups_PageId4798/BlockId6357-Query.lava
+++ b/_code/Block-DynamicData/Report_LifeGroups_PageId4798/BlockId6357-Query.lava
@@ -1,6 +1,6 @@
 /****************************************************************************************
-    This Lava/SQL is found in
-    PageId=4798, [Dynamic Data] > Query
+    This SQL is found in
+    PageId:4798, BlockId:6357, [Dynamic Data] > Query
 
     Path:
     _code/Block-DynamicData/Report_LifeGroups_PageId4798/BlockId6357-Query.lava


### PR DESCRIPTION
Well, not quite a typo, i just copy+pasted without properly changing the right words. It said "Lava and SQL", but the corresponding code only contains "SQL".

It's still saved as a `.lava` file, just in case i do add Lava in the future.