### PR TITLE
Small Fix

### DIFF
--- a/_code/Block-HTMLContent/PageId136/BlockId7482-WorkflowType_Attributes.lava
+++ b/_code/Block-HTMLContent/PageId136/BlockId7482-WorkflowType_Attributes.lava
@@ -14,7 +14,7 @@
 
 {% assign var_WorkflowTypeId = 'Global' | PageParameter:'workflowTypeId' %}
 
-{% if var_WorkflowTypeId != null and var_WorkflowTypeId != empty %}
+{% if var_WorkflowTypeId != null and var_WorkflowTypeId != empty and var_WorkflowTypeId != 0 %}
 
     {% sql return:'sql_WorkflowAttributes' %}
     SELECT


### PR DESCRIPTION
When creating a new WorkflowType, the URL parameter adds workflowTypeId=0, which triggers the logic and messes with the HTML because it attempts to inject the toggled elements.

Adding the `workflowTypeId != 0` prevents this unintended wonkiness.